### PR TITLE
Add AWS command to run AWS CLI commands

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,3 +1,4 @@
+pub mod aws;
 pub mod config;
 pub mod console;
 pub mod kubectl;

--- a/src/commands/aws.rs
+++ b/src/commands/aws.rs
@@ -1,0 +1,17 @@
+use crate::flightctl::aws;
+use crate::flightctl::{AuthConfig, Config, Release};
+
+pub fn run(config: &Config, release: &Release, cmd: &Vec<String>) -> anyhow::Result<()> {
+    let context = config.find_context(release)?;
+    let auth = config.find_auth(context)?;
+
+    match &auth.config {
+        AuthConfig::AwsSso { .. } => aws::run_cli_print(
+            &[
+                vec!["--profile", &auth.name],
+                cmd.iter().map(|s| s.as_ref()).collect(),
+            ]
+            .concat(),
+        ),
+    }
+}

--- a/src/flightctl/aws.rs
+++ b/src/flightctl/aws.rs
@@ -40,6 +40,12 @@ pub fn sso_login(profile: &str) -> anyhow::Result<()> {
     verify_exit(&args, status)
 }
 
+pub fn run_cli_print(args: &[&str]) -> anyhow::Result<()> {
+    let mut child = aws_cli(&args).spawn()?;
+    let status = child.wait()?;
+    verify_exit(&args, status)
+}
+
 pub fn get_eks_cluster(profile: &str, region: &str, name: &str) -> anyhow::Result<EksCluster> {
     let output = run_aws_cli(&[
         "--profile",
@@ -68,6 +74,7 @@ fn run_aws_cli(args: &[&str]) -> anyhow::Result<Output> {
 }
 
 fn aws_cli(args: &[&str]) -> Command {
+    log::debug!("Running AWS CLI with {:?}", args);
     let mut command = Command::new("aws");
     command.args(args);
     command

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,13 @@ struct Opt {
 
 #[derive(Debug, StructOpt)]
 enum Command {
+    /// Run an AWS CLI command for a release
+    Aws {
+        cmd: Vec<String>,
+        #[structopt(flatten)]
+        selector: Selector,
+    },
+
     /// Fetch configuration variables for a release
     Config {
         #[structopt(flatten)]
@@ -116,6 +123,13 @@ fn main() -> anyhow::Result<()> {
     }
 
     match opt.cmd {
+        Some(Command::Aws {
+            ref cmd,
+            ref selector,
+        }) => {
+            let release = preflight(&config, &opt, &selector)?;
+            commands::aws::run(&config, release, cmd)
+        }
         Some(Command::Config { ref selector }) => {
             let release = preflight(&config, &opt, &selector)?;
             commands::config::print(&config, release)


### PR DESCRIPTION
This adds an aws subcommand which can be used to run an AWS CLI command using the profile for a given environment.
