### PR TITLE
Usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In order to use `flightctl` commands to access the workspace, you will need the 
 
 Copy `setup.sh` from `/templates` into your application codebase. We recommend storing it in a `bin/` directory.
 
-TODO: Add descriptions
+The first time the `flightctl` command is used, the script will download the compiled asset for your operating system into your project's `/tmp` directory. Every other time going forward, the command will execute the downloaded binary.
 
 ## Configurations yaml
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 Client for interacting with Mission Control workspaces.
 
+# How to Use
+
+In order to use `flightctl` commands to access the workspace, you will need the files in the `/templates` directory: the setup binary (`setup.sh`) and the configurations yaml (`flightctl.yaml`).
+
+## Setup script
+
+Copy `setup.sh` from `/templates` into your application codebase. We recommend storing it in a `bin/` directory.
+
+TODO: Add descriptions
+
+## Configurations yaml
+
+Copy the configurations template `flightctl.yaml` into your application root directory. Be sure to replace each variable interpolation with real values for your workspace.
+
 ## User Commands
 
 ```

--- a/templates/flightctl.sh
+++ b/templates/flightctl.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+set -e
+
+FLIGHTCTL_VERSION=0.2.0
+PREFIX=$(dirname "$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)")
+FLIGHTCTL_TMP="$PREFIX/tmp"
+FLIGHTCTL_BIN="$FLIGHTCTL_TMP/flightctl-$FLIGHTCTL_VERSION"
+FLIGHTCTL_OS=$(uname 2>/dev/null || echo unknown)
+FLIGHTCTL_ARCH="$(uname -m 2>/dev/null || echo unknown)"
+FLIGHTCTL_REPO="https://github.com/thoughtbot/flightctl"
+
+if [ ! -f "$FLIGHTCTL_BIN" ]; then
+  echo "Installing flightctl $FLIGHTCTL_VERSION..." >&2
+  echo "Operation system: $FLIGHTCTL_OS" >&2
+  echo "Architecture: $FLIGHTCTL_ARCH" >&2
+  mkdir -p "$FLIGHTCTL_TMP" >&2
+
+  case "$FLIGHTCTL_OS/$FLIGHTCTL_ARCH" in
+    Linux/x86_64)
+      FLIGHTCTL_ASSET="flightctl-v$FLIGHTCTL_VERSION-x86_64-unknown-linux-musl"
+      ;;
+    Linux/aarch64)
+      FLIGHTCTL_ASSET="flightctl-v$FLIGHTCTL_VERSION-aarch64-unknown-linux-musl"
+      ;;
+    Darwin/x86_64)
+      FLIGHTCTL_ASSET="flightctl-v$FLIGHTCTL_VERSION-x86_64-apple-darwin"
+      ;;
+    Darwin/arm64)
+      FLIGHTCTL_ASSET="flightctl-v$FLIGHTCTL_VERSION-aarch64-apple-darwin"
+      ;;
+    *)
+      echo "FATAL: Unsupported operating system or architecture." >&2
+      exit 1
+      ;;
+  esac
+
+  FLIGHTCTL_ARCHIVE="$FLIGHTCTL_ASSET.tar.gz"
+  FLIGHTCTL_URL="$FLIGHTCTL_REPO/releases/download/v$FLIGHTCTL_VERSION/$FLIGHTCTL_ARCHIVE"
+  echo "Downloading $FLIGHTCTL_URL..." >&2
+  curl --location "$FLIGHTCTL_URL" --output "$FLIGHTCTL_TMP/$FLIGHTCTL_ARCHIVE"
+  echo "Extracting..." >&2
+  tar vzxf "$FLIGHTCTL_TMP/$FLIGHTCTL_ARCHIVE" -C "$FLIGHTCTL_TMP"
+  cp "$FLIGHTCTL_TMP/$FLIGHTCTL_ASSET/flightctl" "$FLIGHTCTL_BIN"
+  echo "Cleaning up..." >&2
+  rm "$FLIGHTCTL_TMP/$FLIGHTCTL_ARCHIVE"
+  rm -r "$FLIGHTCTL_TMP/$FLIGHTCTL_ASSET"
+  echo "" >&2
+fi
+
+exec "$FLIGHTCTL_BIN" "$@"

--- a/templates/flightctl.yaml
+++ b/templates/flightctl.yaml
@@ -1,0 +1,52 @@
+# Fill in each variable below with real values
+
+apiVersion: flightctl.thoughtbot.com/v1beta1
+kind: Workspace
+releases:
+- name: {release-name}
+  application: {application-name}
+  context: {release-name}
+  environment: {environments}
+  manifests:
+    path: {manifests-path}
+applications:
+- name: {application-name}
+  manifests:
+    provider: kustomize
+    repo: {manifest-repo}
+  provider: kubectl
+  params:
+    selector:
+      {selector-key: selector-value}
+    console:
+      provider: exec
+      params:
+        selector:
+          {console-selector-key: console-selector-value}
+        container: main
+        command:
+        - bundle
+        - exec
+        - rails
+        - console
+contexts:
+- name: {release-name}
+  cluster: {cluster-name}
+  namespace: {namespace}
+  auth: {authentication-name}
+clusters:
+- name: {cluster-name}
+  auth: {authentication-name}
+  provider: eks
+  params:
+    name: {cluster-name}
+    region: {aws-region}
+auth:
+- name: {authentication-name}
+  provider: aws-sso
+  params:
+    region: {aws-region}
+    sso_account_id: {account-id}
+    sso_region: {aws-region}
+    sso_role_name: AWSPowerUserAccess
+    sso_start_url: {aws-sso-url}


### PR DESCRIPTION
The instructions for setting up `flightctl` for any project had been passed down verbally from generation to generation, up until this point.

Adding some basic instructions and templates for the setup script and configuration file.